### PR TITLE
Move `.github-corner` style to corner.css

### DIFF
--- a/css/corner.css
+++ b/css/corner.css
@@ -1,0 +1,39 @@
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
+}
+
+@keyframes octocat-wave {
+    0% {
+        transform: rotate(0deg);
+    }
+
+    20% {
+        transform: rotate(-25deg);
+    }
+
+    40% {
+        transform: rotate(10deg);
+    }
+
+    60% {
+        transform: rotate(-25deg);
+    }
+
+    80% {
+        transform: rotate(10deg);
+    }
+
+    100% {
+        transform: rotate(0deg);
+    }
+}
+
+@media (max-width: 500px) {
+    .github-corner:hover .octo-arm {
+        animation: none;
+    }
+
+    .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out;
+    }
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -3,6 +3,8 @@
  * Author: Tim Holman
  */
 
+@import "corner.css";
+
 * {
     box-sizing: border-box;
 }
@@ -70,46 +72,6 @@ p {
     width: 100%;
     font-family: monospace;
     font-size: 10px;
-}
-
-.github-corner:hover .octo-arm {
-  animation: octocat-wave 560ms ease-in-out;
-}
-
-@keyframes octocat-wave {
-    0% {
-        transform: rotate(0deg);
-    }
-
-    20% {
-        transform: rotate(-25deg);
-    }
-
-    40% {
-        transform: rotate(10deg);
-    }
-
-    60% {
-        transform: rotate(-25deg);
-    }
-
-    80% {
-        transform: rotate(10deg);
-    }
-
-    100% {
-        transform: rotate(0deg);
-    }
-}
-
-@media (max-width: 500px) {
-    .github-corner:hover .octo-arm {
-        animation: none;
-    }
-
-    .github-corner .octo-arm {
-        animation: octocat-wave 560ms ease-in-out;
-    }
 }
 
 /**


### PR DESCRIPTION
Separate the style for `.github-corner` from styles.css and make it available via `npm install tholman/github-corners` as well as SVG.
See also https://github.com/tholman/github-corners/issues/31#issuecomment-623921242.

This does not change the behavior of the demo page.