### PR TITLE
Adds clip-path for clickable area

### DIFF
--- a/css/corner.css
+++ b/css/corner.css
@@ -1,5 +1,5 @@
 .github-corner svg {
-    clip-path: polygon(0 0, 100% 0, 100% 100%)
+    clip-path: polygon(0 0, 100% 0, 100% 100%);
 }
 
 .github-corner:hover .octo-arm {

--- a/css/corner.css
+++ b/css/corner.css
@@ -1,5 +1,5 @@
 .github-corner svg {
-    clip-path: polygon(0 0, 0 100%, 100% 0);
+    clip-path: polygon(0 0, 100% 0, 100% 100%)
 }
 
 .github-corner:hover .octo-arm {

--- a/css/corner.css
+++ b/css/corner.css
@@ -1,3 +1,7 @@
+.github-corner svg {
+    clip-path: polygon(0 0, 0 100%, 100% 0);
+}
+
 .github-corner:hover .octo-arm {
     animation: octocat-wave 560ms ease-in-out;
 }


### PR DESCRIPTION
The github corner clickable area was previosly a square, which would trigger the animation even with the mouse not directly over the svg.
With this PR it clips the svg to fit its appearance, therefore only being clickable and hoverable inside the svg itself.

Video comparing before and after:

https://user-images.githubusercontent.com/42651514/197653769-2a6bca1e-5d00-4fd4-95ad-06256722d89d.mp4

